### PR TITLE
updating to odata 7.0.0-beta4

### DIFF
--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -21,14 +21,14 @@
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Microsoft.Restier.Core/packages.config
+++ b/src/Microsoft.Restier.Core/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.4.3" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.3" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.3" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />

--- a/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
+++ b/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
@@ -24,11 +24,11 @@
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Microsoft.Restier.Providers.EntityFramework/app.config
+++ b/src/Microsoft.Restier.Providers.EntityFramework/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.4.3.20321" newVersion="7.4.3.20321" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Microsoft.Restier.Providers.EntityFramework/packages.config
+++ b/src/Microsoft.Restier.Providers.EntityFramework/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.3" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.3" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net45" />

--- a/src/Microsoft.Restier.Providers.EntityFramework7/App.config
+++ b/src/Microsoft.Restier.Providers.EntityFramework7/App.config
@@ -39,7 +39,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.4.3.20321" newVersion="7.4.3.20321" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/Microsoft.Restier.Providers.EntityFramework7/Microsoft.Restier.Providers.EntityFramework7.csproj
+++ b/src/Microsoft.Restier.Providers.EntityFramework7/Microsoft.Restier.Providers.EntityFramework7.csproj
@@ -58,8 +58,8 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Primitives.1.1.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Remotion.Linq.2.1.1\lib\net45\Remotion.Linq.dll</HintPath>

--- a/src/Microsoft.Restier.Providers.EntityFramework7/packages.config
+++ b/src/Microsoft.Restier.Providers.EntityFramework7/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Extensions.Options" version="1.1.1" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="7.4.3" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net451" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="net451" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />

--- a/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
+++ b/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
@@ -12,8 +12,8 @@
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.OData, Version=7.0.0.20524, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.7.0.0-Nightly201805241245\lib\net45\Microsoft.AspNet.OData.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.OData, Version=7.0.0.20530, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.7.0.0-beta4\lib\net45\Microsoft.AspNet.OData.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
@@ -23,14 +23,14 @@
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.nuspec
+++ b/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.nuspec
@@ -16,7 +16,7 @@
       <dependency id="Microsoft.Restier.Core" version="[1.0.0]" />
       <dependency id="Microsoft.OData.Core" version="[7.0.0, 8.0.0)" />
       <dependency id="Microsoft.Spatial" version="[7.0.0, 8.0.0)" />
-      <dependency id="Microsoft.AspNet.OData" version="[6.0.0,7.0.0)" />
+      <dependency id="Microsoft.AspNet.OData" version="[6.0.0,7.0.1]" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Microsoft.Restier.Publishers.OData/app.config
+++ b/src/Microsoft.Restier.Publishers.OData/app.config
@@ -14,6 +14,18 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Microsoft.Restier.Publishers.OData/packages.config
+++ b/src/Microsoft.Restier.Publishers.OData/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.OData" version="7.0.0-Nightly201805241245" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="7.0.0-beta4" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="7.4.3" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="7.4.3" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="7.4.3" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />


### PR DESCRIPTION
### Issues
This PR upgrades the Microsoft.AspNet.OData dependency since the previous nightly build no longer exists  

